### PR TITLE
Change "who worship" to "who are worshiping"

### DIFF
--- a/revelation.json
+++ b/revelation.json
@@ -1568,7 +1568,7 @@
 		"type": "verse",
 		"chapterNumber": 11,
 		"verseNumber": 1,
-		"text": "I was given a reed like a measuring rod. And the angel stood saying: “Rise and measure the temple of God and the altar, and those who worship there. ",
+		"text": "I was given a reed like a measuring rod. And the angel stood saying: “Rise and measure the temple of God and the altar, and those who are worshiping there. ",
 		"sectionNumber": 1
 	},
 	{


### PR DESCRIPTION
While either translation is correct (since both reflect the present tense), "are worshiping" makes the point very explicit that the worshipers were in existence in John's day. It is a first century temple.