### PR TITLE
Translating ἰδού as "behold" rather than "wow" etc

### DIFF
--- a/revelation.json
+++ b/revelation.json
@@ -155,7 +155,7 @@
 		"type": "verse",
 		"chapterNumber": 1,
 		"verseNumber": 18,
-		"text": "even the Living One—I became dead, to be sure, and now I am living for ever and ever! Oh yes!! And I have the keys of Death and of Hades! ",
+		"text": "even the Living One—I became dead, and behold, now I am living for ever and ever! Oh yes!! And I have the keys of Death and of Hades! ",
 		"sectionNumber": 1
 	},
 	{
@@ -604,7 +604,7 @@
 		"type": "verse",
 		"chapterNumber": 3,
 		"verseNumber": 20,
-		"text": "‘Now then, I stand at the door and knock. If anyone should hear my voice and open the door, I really will come in to him and eat with him, and he with me. ",
+		"text": "‘Behold, I stand at the door and knock. If anyone should hear my voice and open the door, I really will come in to him and eat with him, and he with me. ",
 		"sectionNumber": 1
 	},
 	{
@@ -635,7 +635,7 @@
 		"type": "verse",
 		"chapterNumber": 4,
 		"verseNumber": 1,
-		"text": "After these things I looked and wow—a door standing open in the sky, and the first voice that I heard, like a trumpet speaking with me, saying, “Come up here and I will show you the things that must take place after these.” ",
+		"text": "After these things I looked and behold, a door standing open in the sky, and the first voice that I heard, like a trumpet speaking with me, saying, “Come up here and I will show you the things that must take place after these.” ",
 		"sectionNumber": 1
 	},
 	{
@@ -649,7 +649,7 @@
 		"type": "verse",
 		"chapterNumber": 4,
 		"verseNumber": 2,
-		"text": "And immediately I was in spirit, and there, a throne set in heaven (and One sitting on the throne) ",
+		"text": "And immediately I was in spirit, and behold, a throne set in heaven (and One sitting on the throne) ",
 		"sectionNumber": 1
 	},
 	{
@@ -887,7 +887,7 @@
 		"type": "verse",
 		"chapterNumber": 6,
 		"verseNumber": 2,
-		"text": "And I looked and, wow, a white horse! And he who sat on it had a bow. And a crown was given to him; and he went out conquering, that is, in order to conquer. ",
+		"text": "And I looked and, behold, a white horse! And he who sat on it had a bow. And a crown was given to him; and he went out conquering, that is, in order to conquer. ",
 		"sectionNumber": 1
 	},
 	{
@@ -922,7 +922,7 @@
 		"type": "verse",
 		"chapterNumber": 6,
 		"verseNumber": 5,
-		"text": "And when He opened the third seal I heard the third living being saying, “Come!” And I looked and, wow, a black horse! And he who sat on it had a pair of scales in his hand. ",
+		"text": "And when He opened the third seal I heard the third living being saying, “Come!” And I looked and, behold, a black horse! And he who sat on it had a pair of scales in his hand. ",
 		"sectionNumber": 1
 	},
 	{
@@ -950,7 +950,7 @@
 		"type": "verse",
 		"chapterNumber": 6,
 		"verseNumber": 8,
-		"text": "And I looked and, wow, a sickly pale horse! And as for the one sitting upon it, his name is Death, and Hades follows with him. And authority was given to him over a fourth of the earth, to kill by sword and by famine and by death, also by the wild animals of the earth. ",
+		"text": "And I looked and, behold, a sickly pale horse! And as for the one sitting upon it, his name is Death, and Hades follows with him. And authority was given to him over a fourth of the earth, to kill by sword and by famine and by death, also by the wild animals of the earth. ",
 		"sectionNumber": 1
 	},
 	{
@@ -1107,7 +1107,7 @@
 		"type": "verse",
 		"chapterNumber": 7,
 		"verseNumber": 9,
-		"text": "After these things I looked, and wow, a great multitude that no one could number, from all ethnic nations and tribes and peoples and languages, standing before the Throne and before the Lamb, clothed with white robes and having palm branches in their hands. ",
+		"text": "After these things I looked, and behold, a great multitude that no one could number, from all ethnic nations and tribes and peoples and languages, standing before the Throne and before the Lamb, clothed with white robes and having palm branches in their hands. ",
 		"sectionNumber": 1
 	},
 	{
@@ -1394,7 +1394,7 @@
 		"type": "verse",
 		"chapterNumber": 9,
 		"verseNumber": 12,
-		"text": "The first woe is past, but, two woes are still coming, after these things. ",
+		"text": "The first woe is past, behold, two woes are still coming, after these things. ",
 		"sectionNumber": 1
 	},
 	{
@@ -1674,7 +1674,7 @@
 		"type": "verse",
 		"chapterNumber": 11,
 		"verseNumber": 14,
-		"text": "The second woe is past. Look out, here comes the third woe! ",
+		"text": "The second woe is past. Behold, here comes the third woe! ",
 		"sectionNumber": 1
 	},
 	{
@@ -1747,7 +1747,7 @@
 		"type": "verse",
 		"chapterNumber": 12,
 		"verseNumber": 3,
-		"text": "And another sign appeared in the sky: wow, a dragon, huge, fiery red, having seven heads and ten horns, with seven diadems on his heads. ",
+		"text": "And another sign appeared in the sky: behold, a dragon, huge, fiery red, having seven heads and ten horns, with seven diadems on his heads. ",
 		"sectionNumber": 1
 	},
 	{
@@ -2043,7 +2043,7 @@
 		"type": "verse",
 		"chapterNumber": 14,
 		"verseNumber": 1,
-		"text": "And wow, I saw a Lamb standing on Mount Zion, and with Him one hundred and forty-four thousand, having His name and His Father’s name written on their foreheads. ",
+		"text": "And behold, I saw a Lamb standing on Mount Zion, and with Him one hundred and forty-four thousand, having His name and His Father’s name written on their foreheads. ",
 		"sectionNumber": 1
 	},
 	{
@@ -2157,7 +2157,7 @@
 		"type": "verse",
 		"chapterNumber": 14,
 		"verseNumber": 14,
-		"text": "And wow, I saw a white cloud, and someone like a son of man was sitting on the cloud, having on his head a golden crown, and in his hand a sharp sickle. ",
+		"text": "And behold, I saw a white cloud, and someone like a son of man was sitting on the cloud, having on his head a golden crown, and in his hand a sharp sickle. ",
 		"sectionNumber": 1
 	},
 	{
@@ -2429,7 +2429,7 @@
 		"type": "verse",
 		"chapterNumber": 16,
 		"verseNumber": 15,
-		"text": "(“Watch out, I am coming like a thief. Blessed is the one who watches and guards his clothes, so that he not walk about naked and they see his shame.”) ",
+		"text": "(“Behold, I am coming like a thief. Blessed is the one who watches and guards his clothes, so that he not walk about naked and they see his shame.”) ",
 		"sectionNumber": 1
 	},
 	{
@@ -2934,7 +2934,7 @@
 		"type": "verse",
 		"chapterNumber": 19,
 		"verseNumber": 11,
-		"text": "I saw the heaven opened, and wow, a white horse! And the One who sits on it, called Faithful and True, both judges and makes war with righteousness. ",
+		"text": "I saw the heaven opened, and behold, a white horse! And the One who sits on it, called Faithful and True, both judges and makes war with righteousness. ",
 		"sectionNumber": 1
 	},
 	{
@@ -3179,7 +3179,7 @@
 		"type": "verse",
 		"chapterNumber": 21,
 		"verseNumber": 3,
-		"text": "And I heard a loud voice from heaven saying: “Take note, the tabernacle of God is with men and He will dwell with them, and they will be His people. Yes, God Himself will be with them. ",
+		"text": "And I heard a loud voice from heaven saying: “Behold, the tabernacle of God is with men and He will dwell with them, and they will be His people. Yes, God Himself will be with them. ",
 		"sectionNumber": 1
 	},
 	{
@@ -3196,7 +3196,7 @@
 		"type": "verse",
 		"chapterNumber": 21,
 		"verseNumber": 5,
-		"text": "Then He who sat on the throne said, “Take note, I make everything new!” And He says to me, “Write, because these words are true and faithful!” ",
+		"text": "Then He who sat on the throne said, “Behold, I make everything new!” And He says to me, “Write, because these words are true and faithful!” ",
 		"sectionNumber": 1
 	},
 	{
@@ -3427,7 +3427,7 @@
 		"type": "verse",
 		"chapterNumber": 22,
 		"verseNumber": 7,
-		"text": "Take note, I am coming swiftly! Blessed is the one who keeps the words of the prophecy of this book.” ",
+		"text": "Behold, I am coming swiftly! Blessed is the one who keeps the words of the prophecy of this book.” ",
 		"sectionNumber": 1
 	},
 	{
@@ -3472,7 +3472,7 @@
 		"type": "verse",
 		"chapterNumber": 22,
 		"verseNumber": 12,
-		"text": "“Take note, I am coming swiftly, and my reward is with me to give to each one according to his work. ",
+		"text": "“Behold, I am coming swiftly, and my reward is with me to give to each one according to his work. ",
 		"sectionNumber": 1
 	},
 	{


### PR DESCRIPTION
"Behold" is a more literal rendering of ἰδού, has the familiarity of agreement with most other translations, and is less informal than "wow."  While "wow" might carry some of the connotation of the word, it doesn't have the right denotation. Furthermore, Pickering is not always consistent in his translation of this word, sometimes rendering it "but," "then," "take note." While "take note" is a fairly decent translation, "Behold" has a ring of familiarity with other translations and gives a more literal rendering. Therefore I have changed every occurrence of ἰδού with "behold."
Josh, could you do a global replace of all occurrences of "wow" with "behold." Otherwise I will manually change 1:7,18; 3:11,20; 4:1,2; 5:5,6; 6:12 [I already changed 6:2,5,8], 7:9; 9:12; 11:14; 12:3; 14:1