### PR TITLE
"Saved by" to "Salvation belongs to"

### DIFF
--- a/revelation.json
+++ b/revelation.json
@@ -1114,7 +1114,7 @@
 		"type": "verse",
 		"chapterNumber": 7,
 		"verseNumber": 10,
-		"text": "And they shouted with a loud voice saying, “Saved by our God who sits on the throne, and by the Lamb!” ",
+		"text": "And they shouted with a loud voice saying, “Salvation belongs to our God who sits on the throne, and by the Lamb!” ",
 		"sectionNumber": 1
 	},
 	{


### PR DESCRIPTION
This may seem like a minor change, but my sermon shows the theological import of the change. The Greek is not a verb, but a noun followed by a dative. Therefore Ἡ σωτηρία τῷ θεῷ ἡμῶν  is more literally rendered "The salvation belongs to our God."