### PR TITLE
Consistency in translating κρατέω

### DIFF
--- a/revelation.json
+++ b/revelation.json
@@ -294,7 +294,7 @@
 		"type": "verse",
 		"chapterNumber": 2,
 		"verseNumber": 13,
-		"text": "‘I know your works, and where you live, where Satan’s throne is. And you hold my name fast and did not deny my faith during the days in which Antipas was my faithful witness, who was killed among you, where Satan lives. ",
+		"text": "‘I know your works, and where you live, where Satan’s throne is. And you hold fast to my name and did not deny my faith during the days in which Antipas was my faithful witness, who was killed among you, where Satan lives. ",
 		"sectionNumber": 1
 	},
 	{
@@ -304,14 +304,14 @@
 		"type": "verse",
 		"chapterNumber": 2,
 		"verseNumber": 14,
-		"text": "‘Nevertheless I have a few things against you, because you have there adepts of the doctrine of Balaam, who taught Balak to throw a stumbling block before the sons of Israel, to eat things offered to idols and to fornicate. ",
+		"text": "‘Nevertheless I have a few things against you, because you have there those who hold fast to the doctrine of Balaam, who taught Balak to throw a stumbling block before the sons of Israel, to eat things offered to idols and to fornicate. ",
 		"sectionNumber": 1
 	},
 	{
 		"type": "verse",
 		"chapterNumber": 2,
 		"verseNumber": 15,
-		"text": "Thus you also have adepts of the doctrine of the Nicolaitans as well. ",
+		"text": "Thus you also have those who hold fast to the doctrine of the Nicolaitans as well. ",
 		"sectionNumber": 1
 	},
 	{


### PR DESCRIPTION
In my sermon on 2:12-17 I show that there is a critical point being made by the Greek word κρατέω. These three changes keep the translation of κρατέω consistent so that point can be more clearly seen.