### PR TITLE
Adding "and" to 14:6

### DIFF
--- a/revelation.json
+++ b/revelation.json
@@ -2085,7 +2085,7 @@
 		"type": "verse",
 		"chapterNumber": 14,
 		"verseNumber": 6,
-		"text": "And I saw another angel flying in mid-heaven, having an eternal gospel to be proclaimed to those who reside on the earth—to every ethnic nation and tribe and language and people— ",
+		"text": "And I saw another angel flying in mid-heaven, having an eternal gospel to be proclaimed to those who reside on the earth, and to every ethnic nation and tribe and language and people— ",
 		"sectionNumber": 1
 	},
 	{


### PR DESCRIPTION
This is because "earth" refers to Israel, and there is a και immediately after it. Pickering no doubt interpreted the και  as an "even" or "that is" (no doubt because he fails to see that γῆς is a reference to Israel). However, I take it as a sequence of και words indicating that this message went beyond Israel.