### PR TITLE
change "spirits of demons" to "demonic spirits"

### DIFF
--- a/revelation.json
+++ b/revelation.json
@@ -2422,7 +2422,7 @@
 		"type": "verse",
 		"chapterNumber": 16,
 		"verseNumber": 14,
-		"text": "For they are spirits of demons, performing signs, which go out to the kings of the whole inhabited earth, to gather them to the battle of that great day of God Almighty. ",
+		"text": "For they are demonic spirits, performing signs, which go out to the kings of the whole inhabited earth, to gather them to the battle of that great day of God Almighty. ",
 		"sectionNumber": 1
 	},
 	{


### PR DESCRIPTION
I could have left it and explained what most commentaries say the grammar requires, but it might as well be translated correctly.